### PR TITLE
Optimize jac_structure! and hess_structure! functions

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -323,9 +323,9 @@ function NLPModels.jac_structure!(model :: RADNLPModel, rows :: AbstractVector{<
   @variables xs[1:model.meta.nvar]
   _fun = model.c(xs)
   Jx   = Symbolics.jacobian_sparsity(_fun, xs)
-  #Tangi: We should do better here!
-  rows .= findnz(Jx)[1]
-  cols .= findnz(Jx)[2]
+  I, J, _ = findnz(Jx)
+  rows .= I
+  cols .= J
   return rows, cols
 end
 
@@ -355,6 +355,8 @@ function NLPModels.jprod!(model :: RADNLPModel, x :: AbstractVector, v :: Abstra
   increment!(model, :neval_jprod)
   #Option 1: ForwardDiff
   Jv .= ForwardDiff.derivative(t -> model.c(x + t * v), 0)
+  #Option 2: SparseDiffTools
+  #Jv .= auto_jacvec(f, x, v)
   return Jv
 end
 
@@ -378,8 +380,9 @@ function NLPModels.hess_structure!(model :: RADNLPModel, rows :: AbstractVector{
     _fun = model.f(xs)
   end
   H = tril(Symbolics.hessian_sparsity(_fun, xs))
-  rows .= findnz(H)[1]
-  cols .= findnz(H)[2]
+  I, J, _ = findnz(H)
+  rows .= I
+  cols .= J
   return rows, cols
 end
 


### PR DESCRIPTION
@tmigot 

Salut Tangi, j'ai regardé pour faire des opérateurs J*v et H*v performants et c'est pas vraiment possible dans notre cas pour deux raisons : 
- J*v a besoin que la fonction des contraintes soit de la forme `c(storage, x)`, ce qui n'est pas le cas avec `NLPModels.jl`. On ne peut donc pas utiliser de `Tape` pour modéliser un opérateur plus économique en mémoire que ce qu'on a déjà.
- H*v a la bonne structure pour être in-place mais malheureusement la fonction `ℓ(x)` est différente à chaque appel de `hprod!`, ce qui oblige a calculer un nouveau `GradientConfig` et ça revient à pratiquement rien faire in-place.

J'ai juste optimisé `jac_structure!` et `hess_structure!` pour s'éviter le double appel à `findnz`.